### PR TITLE
Fix the [WARNING] example in Chapter 4.

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -407,7 +407,7 @@ Here's some text inside a note.
 You'd create a tip with a title like so:
 
 ----
-.Tip Title
+.Titled Tip
 [TIP]
 ====
 Here's some text inside a tip.
@@ -426,8 +426,8 @@ Here's some text inside a tip.
 Or you could use a warning:
 
 ----
-.Warning Title
-[TIP]
+.Titled Warning
+[WARNING]
 ====
 Here's some text inside a warning.
 ====


### PR DESCRIPTION
The wrong syntax is used for the Warning example. It should be [WARNING] not [TIP].

Also, the rendered titles don’t match the code for the titles. That makes it unclear if the word "Tip” is significant in the `.Tip Title` line. (It isn’t.)
